### PR TITLE
fix: Ensure 'Our Offerings' link works across pages

### DIFF
--- a/src/components/navigation.jsx
+++ b/src/components/navigation.jsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button"
 import { useState, useEffect, useRef } from "react"
 import { Menu, X, Users, DollarSign, Download, LogIn, Home, ChevronDown } from "lucide-react"
 import { ThemeToggle } from "@/components/theme-toggle"
-import { usePathname } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation" // Added useRouter
 import { AppDownloadModal } from "../components/AppDownloadModal"; // Changed to named import
 import LoginModal from "../components/LoginModal" // Added import
 import { LoopAgentModal } from "../components/LoopAgentModal";
@@ -17,16 +17,21 @@ export function Navigation() {
   const [isLoopAgentModalOpen, setIsLoopAgentModalOpen] = useState(false);
   const [isFoundersOpen, setIsFoundersOpen] = useState(false)
   const [isMobileFoundersOpen, setIsMobileFoundersOpen] = useState(false)
+  const router = useRouter() // Added router instance
   const pathname = usePathname()
   const foundersDropdownRef = useRef(null)
 
   // Scroll to Our Offerings
   const handleScrollToOurOfferings = () => {
-    if (typeof window !== 'undefined') {
-      const element = document.getElementById('services');
-      if (element) {
-        element.scrollIntoView({ behavior: 'smooth' });
+    if (pathname === '/') {
+      if (typeof window !== 'undefined') {
+        const element = document.getElementById('services');
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth' });
+        }
       }
+    } else {
+      router.push('/#services');
     }
     setIsMenuOpen(false);
     setIsMobileFoundersOpen(false);


### PR DESCRIPTION
Previously, the 'Our Offerings' link in the 'For Founders' dropdown only scrolled to the section if you were already on the homepage.

This commit updates the functionality:
- If you are on a page other than the homepage (e.g., /pricing), clicking 'Our Offerings' will first navigate you to the homepage and then jump to the 'Our Offerings' section (using /#services hash).
- If you are already on the homepage, it will smoothly scroll to the section as before.
- All relevant menus (desktop dropdown, mobile main menu, mobile 'For Founders' submenu) are closed after the action.

This ensures consistent and correct behavior for the 'Our Offerings' navigation item from anywhere on the site.