### PR TITLE
Fix: Improve responsiveness of footer links

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -181,7 +181,7 @@ export default function Footer() {
         {/* Bottom Footer */}
         <div className="border-t border-gray-200 dark:border-gray-800 pt-8 flex flex-col md:flex-row justify-between items-center animate-on-scroll">
           <p className="text-gray-600 dark:text-gray-400 mb-4 md:mb-0">© 2024 Venturloop. All rights reserved.</p>
-          <div className="flex flex-wrap justify-center md:justify-end space-x-6">
+          <div className="flex flex-wrap justify-center gap-x-6 gap-y-2">
             <a
               href="/privacy-policy"
               className="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors text-sm"


### PR DESCRIPTION
The links in the bottom section of the footer (Privacy Policy, Terms, Sitemap, etc.) were not displaying optimally on mobile and tablet sizes.

This change adjusts the Tailwind CSS classes for the container of these links. Specifically, it changes from 'justify-center md:justify-end space-x-6' to 'justify-center gap-x-6 gap-y-2'.

This ensures that:
- Links are consistently centered on all screen sizes.
- `gap-x-6` maintains horizontal spacing.
- `gap-y-2` adds vertical spacing when items wrap to new lines, improving readability.