### PR TITLE
Fix: Add dark mode borders to feature cards

### DIFF
--- a/src/components/home-client.jsx
+++ b/src/components/home-client.jsx
@@ -290,7 +290,7 @@ export default function HomeClient() {
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-0 lg:w-full lg:h-full lg:relative justify-items-center">
                 {/* Quick Transfer - Top Left */}
                 <div className="lg:absolute lg:top-8 lg:left-8 xl:left-16 animate-on-scroll animate-delay-300">
-                  <div className="bg-white dark:bg-gray-900 p-6 rounded-2xl shadow-lg max-w-xs hover-lift">
+                  <div className="bg-white dark:bg-gray-900 dark:border dark:border-gray-700 p-6 rounded-2xl shadow-lg max-w-xs hover-lift">
                     <div className="w-12 h-12 bg-blue-100 dark:bg-blue-900 rounded-xl flex items-center justify-center mb-4">
                       <Users className="w-6 h-6 text-blue-600 dark:text-blue-500" />
                     </div>
@@ -303,7 +303,7 @@ export default function HomeClient() {
 
                 {/* Easy Management - Top Right */}
                 <div className="lg:absolute lg:top-8 lg:right-8 xl:right-16 animate-on-scroll animate-delay-400">
-                  <div className="bg-white dark:bg-gray-900 p-6 rounded-2xl shadow-lg max-w-xs hover-lift">
+                  <div className="bg-white dark:bg-gray-900 dark:border dark:border-gray-700 p-6 rounded-2xl shadow-lg max-w-xs hover-lift">
                     <div className="w-12 h-12 bg-green-100 dark:bg-green-900 rounded-xl flex items-center justify-center mb-4">
                       <Briefcase className="w-6 h-6 text-green-600 dark:text-green-500" />
                     </div>
@@ -316,7 +316,7 @@ export default function HomeClient() {
 
                 {/* Expense Tracking - Bottom Left */}
                 <div className="lg:absolute lg:bottom-8 lg:left-8 xl:left-16 animate-on-scroll animate-delay-500">
-                  <div className="bg-white dark:bg-gray-900 p-6 rounded-2xl shadow-lg max-w-xs hover-lift">
+                  <div className="bg-white dark:bg-gray-900 dark:border dark:border-gray-700 p-6 rounded-2xl shadow-lg max-w-xs hover-lift">
                     <div className="w-12 h-12 bg-purple-100 dark:bg-purple-900 rounded-xl flex items-center justify-center mb-4">
                       <GitFork className="w-6 h-6 text-purple-600 dark:text-purple-500" />
                     </div>
@@ -329,7 +329,7 @@ export default function HomeClient() {
 
                 {/* Track Your Investment - Bottom Right */}
                 <div className="lg:absolute lg:bottom-8 lg:right-8 xl:right-16 animate-on-scroll animate-delay-600">
-                  <div className="bg-white dark:bg-gray-900 p-6 rounded-2xl shadow-lg max-w-xs hover-lift">
+                  <div className="bg-white dark:bg-gray-900 dark:border dark:border-gray-700 p-6 rounded-2xl shadow-lg max-w-xs hover-lift">
                     <div className="w-12 h-12 bg-orange-100 dark:bg-orange-900 rounded-xl flex items-center justify-center mb-4">
                       <Brain className="w-6 h-6 text-orange-600 dark:text-orange-500" />
                     </div>


### PR DESCRIPTION
The feature cards in the "Our Offerings" section of the landing page were blending with the background in dark mode.

This commit adds a 1px gray border to these cards specifically in dark mode using Tailwind CSS utility classes. This improves visual separation without affecting the light mode appearance.