### PR TITLE
feat: Add 'My Connections' modal to profile page

### DIFF
--- a/src/app/profile/[userId]/page.jsx
+++ b/src/app/profile/[userId]/page.jsx
@@ -10,6 +10,7 @@ import { useUser } from "@/context/UserContext.js";
 import LoginModal from "@/components/LoginModal.jsx";
 import { EditProfileModal } from "@/components/EditProfileModal.jsx";
 import { ShareProfileModal } from "@/components/ShareProfileModal.jsx";
+import { MyConnectionsModal } from "@/components/MyConnectionsModal.jsx";
 import Footer from '@/components/Footer.jsx';
 
 // Mock data - will be replaced or fetched based on userId
@@ -62,6 +63,8 @@ export default function UserProfilePage() {
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+  const [isMyConnectionsModalOpen, setIsMyConnectionsModalOpen] = useState(false);
+  const [connectionsData, setConnectionsData] = useState({ list: [], total: 0 });
   const [profileUrl, setProfileUrl] = useState('');
 
   useEffect(() => {
@@ -131,6 +134,30 @@ export default function UserProfilePage() {
     alert("Connect request functionality not yet implemented.");
   };
 
+  const handleOpenConnectionsModal = () => {
+    const displayedTotalConnections = totalConnections || 0; // from userProfileData or currentUser
+
+    if (isOwnProfile && currentUser) {
+      // For own profile, use a specific mock list. The total should match currentUser.totalConnections.
+      const ownMockList = [
+        { userId: 'connUser1', name: 'My Connection Alpha', profilePhotoUrl: '/placeholder.jpg', bio: 'Alpha bio - connected to me.' },
+        { userId: 'connUser2', name: 'My Connection Beta', profilePhotoUrl: '/placeholder.jpg', bio: 'Beta bio - also connected.' },
+        { userId: 'connUser3', name: 'My Connection Gamma', profilePhotoUrl: '/placeholder.jpg', bio: 'Gamma - another connection.' },
+      ];
+      // Adjust list to not exceed actual total, though ideally mock list length matches total
+      setConnectionsData({ list: ownMockList.slice(0, displayedTotalConnections), total: displayedTotalConnections });
+    } else {
+      // For viewing another user's profile, use a different mock set.
+      // The total should match userProfileData.totalConnections for the viewed user.
+      const otherUserMockList = [
+        { userId: 'otherConnA', name: 'Other User Connection A', profilePhotoUrl: '/placeholder.jpg', bio: 'Viewing another profile\'s connection A.' },
+        { userId: 'otherConnB', name: 'Other User Connection B', profilePhotoUrl: '/placeholder.jpg', bio: 'Viewing another profile\'s connection B.' },
+      ];
+      setConnectionsData({ list: otherUserMockList.slice(0, displayedTotalConnections), total: displayedTotalConnections });
+    }
+    setIsMyConnectionsModalOpen(true);
+  };
+
   return (
     <>
       <Navigation />
@@ -171,10 +198,15 @@ export default function UserProfilePage() {
                 </div>
               <div className="w-full text-center md:text-left pt-4 border-t border-gray-200 dark:border-gray-700 mt-4">
                  <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">Stats</h3>
-                 <div className="flex items-center justify-center md:justify-start text-gray-600 dark:text-gray-400 mb-2">
-                   <Users size={18} className="mr-2 text-blue-500 dark:text-blue-400" />
-                   <span>{totalConnections || 0} Connections</span>
-                 </div>
+                  <button
+                    onClick={(totalConnections || 0) > 0 ? handleOpenConnectionsModal : undefined}
+                    disabled={!((totalConnections || 0) > 0)}
+                    className={`flex items-center justify-center md:justify-start text-gray-600 dark:text-gray-400 mb-2 w-full text-left ${(totalConnections || 0) > 0 ? 'cursor-pointer hover:opacity-80' : 'cursor-default'}`}
+                    aria-label={(totalConnections || 0) > 0 ? "View connections" : "No connections"}
+                  >
+                    <Users size={18} className="mr-2 text-blue-500 dark:text-blue-400 flex-shrink-0" />
+                    <span>{totalConnections || 0} Connection{(totalConnections || 0) !== 1 ? 's' : ''}</span>
+                  </button>
                  <div className="flex items-center justify-center md:justify-start text-gray-600 dark:text-gray-400">
                    <Eye size={18} className="mr-2 text-blue-500 dark:text-blue-400" />
                    <span>{viewCount || 0} Profile Views</span>
@@ -255,6 +287,12 @@ export default function UserProfilePage() {
         isOpen={isShareModalOpen}
         onClose={() => setIsShareModalOpen(false)}
         profileUrl={profileUrl}
+      />
+      <MyConnectionsModal
+        isOpen={isMyConnectionsModalOpen}
+        onClose={() => setIsMyConnectionsModalOpen(false)}
+        connectionsList={connectionsData.list}
+        totalConnections={connectionsData.total}
       />
       <Footer />
     </>

--- a/src/components/MyConnectionsModal.jsx
+++ b/src/components/MyConnectionsModal.jsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useRouter } from 'next/navigation';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { User, UserMinus, X } from 'lucide-react'; // X can be an alternative close icon if needed, User for view profile
+
+export function MyConnectionsModal({ isOpen, onClose, connectionsList = [], totalConnections = 0 }) {
+  const router = useRouter();
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleViewProfile = (userId) => {
+    console.log("View profile:", userId);
+    router.push(`/profile/${userId}`);
+    onClose(); // Close modal after navigation
+  };
+
+  const handleRemoveConnection = (userId) => {
+    console.log("Remove connection:", userId);
+    // TODO: API call to remove connection
+    // Then potentially update connectionsList or refetch
+    alert(`Placeholder: Remove connection for user ${userId}`);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-lg max-h-[80vh] flex flex-col p-0">
+        <DialogHeader className="p-6 pb-4 border-b dark:border-gray-700">
+          <DialogTitle className="flex items-center justify-between">
+            My Connections ({totalConnections})
+            {/* Optional explicit close button in header if design calls for it, usually DialogClose in footer is enough */}
+            {/* <Button variant="ghost" size="icon" onClick={onClose} className="rounded-full">
+              <X className="h-4 w-4" />
+            </Button> */}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex-grow overflow-y-auto px-6 py-4 space-y-3">
+          {connectionsList && connectionsList.length > 0 ? (
+            connectionsList.map((connection) => (
+              <div
+                key={connection.userId}
+                className="flex items-center space-x-3 p-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-150"
+              >
+                <img
+                  src={connection.profilePhotoUrl || '/placeholder.jpg'}
+                  alt={connection.name}
+                  className="w-10 h-10 rounded-full object-cover flex-shrink-0"
+                />
+                <div className="flex-grow min-w-0">
+                  <p className="font-semibold text-sm text-gray-900 dark:text-white truncate">
+                    {connection.name}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                    {connection.bio || 'No bio available.'}
+                  </p>
+                </div>
+                <div className="flex space-x-1 flex-shrink-0">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleViewProfile(connection.userId)}
+                    title="View Profile"
+                    className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                  >
+                    <User className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleRemoveConnection(connection.userId)}
+                    title="Remove Connection"
+                    className="text-red-500 hover:text-red-600 dark:text-red-500 dark:hover:text-red-400"
+                  >
+                    <UserMinus className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            ))
+          ) : (
+            <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-10">
+              No connections yet. Start networking to build your connections!
+            </p>
+          )}
+        </div>
+
+        <DialogFooter className="p-6 pt-4 border-t dark:border-gray-700">
+          <Button variant="outline" onClick={onClose}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// Example defaultProps for robustness, though not strictly required by subtask
+MyConnectionsModal.defaultProps = {
+  connectionsList: [],
+  totalConnections: 0,
+};


### PR DESCRIPTION
Introduces a 'My Connections' modal accessible from your profile page.

Key Features:
- A new `MyConnectionsModal.jsx` component is created to display a list of your connections.
- The connections count in the profile page's stats section is now clickable (if connections > 0) and opens this modal.
- The modal displays the total number of connections in its title.
- Each connection in the list shows:
    - Profile picture (with a placeholder if no image is available).
    - Name (truncated if too long).
    - Bio (truncated if too long, with a placeholder if no bio).
- For each connection, action buttons are provided:
    - 'View Profile': Navigates to the respective user's profile page and closes the modal.
    - 'Remove Connection': Currently a placeholder action that logs to the console and shows an alert.
- The modal content is scrollable if the list of connections exceeds the modal's max height.
- The modal is responsive and designed not to cover the full screen.
- Handles the case where there are no connections by displaying an appropriate message.
- Uses mock data for displaying the list of connections; actual data fetching is a future backend task.
- Conceptual API requirements for fetching connections and removing a connection have been defined.

This feature enhances user engagement by allowing you to see and interact with your list of connections directly from your profile.