### PR TITLE
Fix: Correct 'Get Started' flow in PhoneMockup3

### DIFF
--- a/src/components/home-client.jsx
+++ b/src/components/home-client.jsx
@@ -125,6 +125,14 @@ export default function HomeClient() {
   const openAppDownloadModal = () => setIsAppDownloadModalOpen(true);
   const closeAppDownloadModal = () => setIsAppDownloadModalOpen(false);
 
+  const handleGetStartedClick = () => {
+    if (isLoggedIn) {
+      openAppDownloadModal();
+    } else {
+      openLoginModal();
+    }
+  };
+
   // Scroll animation observer
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -544,7 +552,7 @@ export default function HomeClient() {
             </div>
 
             <div className="w-full lg:w-1/2 flex justify-center animate-on-scroll animate-delay-200">
-              <PhoneMockup3 onGetStartedClick={openLoginModal} />
+              <PhoneMockup3 onGetStartedClick={handleGetStartedClick} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Previously, the 'Get Started' button in PhoneMockup3 always opened the LoginModal, regardless of your login status.

This change introduces a new handler function, `handleGetStartedClick`, in `home-client.jsx`. This function checks if you are logged in.
- If logged in, it opens the AppDownloadModal directly.
- If not logged in, it opens the LoginModal.

The `PhoneMockup3` component in `home-client.jsx` has been updated to use this new handler, ensuring the correct modal is displayed based on your authentication state.